### PR TITLE
get icon correctly for MIUI

### DIFF
--- a/src/com/android/launcher3/IconProvider.java
+++ b/src/com/android/launcher3/IconProvider.java
@@ -1,6 +1,8 @@
 package com.android.launcher3;
 
+import android.content.Context;
 import android.content.pm.LauncherActivityInfo;
+import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 
@@ -10,10 +12,12 @@ public class IconProvider {
 
     private static final boolean DBG = false;
     private static final String TAG = "IconProvider";
+    protected final Context mContext;
 
     protected String mSystemState;
 
-    public IconProvider() {
+    public IconProvider(Context context) {
+        mContext = context;
         updateSystemStateString();
     }
 
@@ -30,6 +34,11 @@ public class IconProvider {
      *                        original icon as long as the flattened version looks the same.
      */
     public Drawable getIcon(LauncherActivityInfo info, int iconDpi, boolean flattenDrawable) {
-        return info.getIcon(iconDpi);
+        try {
+            PackageManager pm = mContext.getPackageManager();
+            return pm.getActivityIcon(info.getComponentName());
+        } catch (PackageManager.NameNotFoundException e) {
+            return info.getIcon(iconDpi);
+        }
     }
 }

--- a/src/com/google/android/apps/nexuslauncher/CustomIconProvider.java
+++ b/src/com/google/android/apps/nexuslauncher/CustomIconProvider.java
@@ -36,14 +36,12 @@ import java.util.Set;
 public class CustomIconProvider extends DynamicIconProvider {
     public final static String DISABLE_PACK_PREF = "all_apps_disable_pack";
 
-    private final Context mContext;
     private CustomDrawableFactory mFactory;
     private final BroadcastReceiver mDateChangeReceiver;
     private int mDateOfMonth;
 
     public CustomIconProvider(Context context) {
         super(context);
-        mContext = context;
         mFactory = (CustomDrawableFactory) DrawableFactory.get(context);
 
         mDateChangeReceiver = new BroadcastReceiver() {

--- a/src/com/google/android/apps/nexuslauncher/DynamicIconProvider.java
+++ b/src/com/google/android/apps/nexuslauncher/DynamicIconProvider.java
@@ -30,12 +30,12 @@ import java.util.List;
 public class DynamicIconProvider extends IconProvider {
     public static final String GOOGLE_CALENDAR = "com.google.android.calendar";
     private final BroadcastReceiver mDateChangeReceiver;
-    private final Context mContext;
     private final PackageManager mPackageManager;
     private int mDateOfMonth;
 
     public DynamicIconProvider(Context context) {
-        mContext = context;
+        super(context);
+        //mContext = context;
         mDateChangeReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
For MIUI, this launcher will got default icon build into apk.
and miui's default is really ugly, and they never update there icon.
this patch get icon from package manager, and will get icon form miui theme manager.