### PR TITLE
Fix values-uz string translation build error

### DIFF
--- a/res/values-uz/strings.xml
+++ b/res/values-uz/strings.xml
@@ -151,7 +151,7 @@
     <string name="theme_automatic">Avtomatik</string>
     <string name="theme_default">Standart</string>
     <string name="theme_light">Nur</string>
-    <string name="theme_dark">Qorong'i</string>
+    <string name="theme_dark">Qorong‘i</string>
     <string name="theme_transparent">Shaffof</string>
     <string name="pref_open_source_licenses_title">Ochiq kodli DT litsenziyalari</string>
 </resources>


### PR DESCRIPTION
packages/apps/Launcher3/res/values-uz/strings.xml:154: error: Apostrophe not preceded by \ (in Qorong'i)