### PR TITLE
 fix NumberFormatException and values-uz

### DIFF
--- a/res/values-uz/strings.xml
+++ b/res/values-uz/strings.xml
@@ -151,7 +151,7 @@
     <string name="theme_automatic">Avtomatik</string>
     <string name="theme_default">Standart</string>
     <string name="theme_light">Nur</string>
-    <string name="theme_dark">Qorong'i</string>
+    <string name="theme_dark">Qorong\'i</string>
     <string name="theme_transparent">Shaffof</string>
     <string name="pref_open_source_licenses_title">Ochiq kodli DT litsenziyalari</string>
 </resources>

--- a/src/com/android/launcher3/shortcuts/DeepShortcutManagerBackport.java
+++ b/src/com/android/launcher3/shortcuts/DeepShortcutManagerBackport.java
@@ -90,7 +90,8 @@ public class DeepShortcutManagerBackport {
                         }
                         if (parsedData.containsKey("name") &&
                                 parsedData.get("name").equals("android.app.shortcuts") &&
-                                parsedData.containsKey("resource")) {
+                                parsedData.containsKey("resource") &&
+                                parsedData.get("resource").matches("@\\d+")) {
                             resource = parsedData.get("resource");
                         }
                     }


### PR DESCRIPTION
for some reason on android 7.0 (and probably 7.1) parsedData.get("resource") returns "@xml/resource" and causing crash (NumberFormatException) in line 102 when parsed into integer (since its not numerical).